### PR TITLE
Cleanup downloads folder after import prompt

### DIFF
--- a/modules/sales.py
+++ b/modules/sales.py
@@ -538,6 +538,17 @@ class SalesWidget(QWidget):
                             dest_path = os.path.join(self.db.statements_dir, base_name)
                             shutil.copy2(file_path, dest_path)
                         
+                        # After all files are imported, then ask about cleanup
+                        if scan_downloads and statement_files_by_month:
+                            if QMessageBox.question(self, "Cleanup Downloads", "Remove imported files from Downloads?", 
+                                QMessageBox.Yes | QMessageBox.No) == QMessageBox.Yes:
+                                for file_path in statement_files_by_month.values():
+                                    try:
+                                        os.remove(file_path)
+                                    except Exception as e:
+                                        print(f"Failed to remove {file_path}: {str(e)}")
+
+                        # Refresh the table
                         self.refresh_table()
                         return
                     


### PR DESCRIPTION
This pull request includes a significant update to the `import_statement` method in the `modules/sales.py` file. The most important change is the addition of a cleanup prompt for removing imported files from the Downloads folder after the import process is completed.

Enhancements to the import process:

* Added a prompt to ask the user whether they want to remove the imported files from the Downloads folder after all files are imported. If the user selects "Yes," the files are deleted.
* Included error handling to catch and print exceptions if any files fail to be removed during the cleanup process.