### PR TITLE
Add version number to settings screen

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -1,5 +1,5 @@
 #define MyAppName "EtsyTrackr"
-#define MyAppVersion "0.0.4"
+#define MyAppVersion "0.0.5"
 #define MyAppPublisher "EtsyTrackr"
 #define MyAppURL "https://github.com/go2engle/EtsyTrackr"
 #define MyAppExeName "EtsyTrackr.exe"

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -4,6 +4,7 @@ from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QIcon
 import os
 import shutil
+from .version import VersionChecker
 
 class SettingsWidget(QWidget):
     storage_location_changed = Signal(str)
@@ -68,8 +69,13 @@ class SettingsWidget(QWidget):
         
         layout.addWidget(storage_section)
         
-        # Add stretch at the end
-        layout.addStretch()
+        # Add a subtle version number at the bottom right
+        version_label = QLabel(f"v{VersionChecker.CURRENT_VERSION.lstrip('v')}")
+        version_label.setStyleSheet("color: gray;")
+        version_label.setAlignment(Qt.AlignRight)
+        layout.addStretch()  # This pushes the version to the bottom
+        layout.addWidget(version_label)
+        
         self.setLayout(layout)
     
     def create_section(self, title):

--- a/modules/version.py
+++ b/modules/version.py
@@ -5,7 +5,7 @@ import webbrowser
 class VersionChecker:
     GITHUB_API_URL = "https://api.github.com/repos/go2engle/EtsyTrackr/releases/latest"
     GITHUB_RELEASES_URL = "https://github.com/go2engle/EtsyTrackr/releases/latest"
-    CURRENT_VERSION = "v0.0.4"  # This should match your current version
+    CURRENT_VERSION = "v0.0.5"  # This should match your current version
 
     @classmethod
     def check_for_updates(cls):


### PR DESCRIPTION
This pull request includes updates to the version number and enhancements to the settings UI. The most important changes include updating the version number from `0.0.4` to `0.0.5` and adding a version label to the settings widget.

Version updates:

* [`installer.iss`](diffhunk://#diff-72e96ba8fc218bf3c064839eb76a1c3fd565d88d921c7ab3205ba6d988fc4cf1L2-R2): Updated `MyAppVersion` from "0.0.4" to "0.0.5".
* [`modules/version.py`](diffhunk://#diff-953f719589a8eea5d661d52446ad6e68fe8de0b53f73ea400a4138d1bbb9cfa5L8-R8): Updated `CURRENT_VERSION` from "v0.0.4" to "v0.0.5".

UI enhancements:

* [`modules/settings.py`](diffhunk://#diff-206b4c3d6f3351d2be429c8cb655fa22115c8af62a3708b5cadc9239d44c40eaR7): Imported `VersionChecker` to use its `CURRENT_VERSION` attribute.
* [`modules/settings.py`](diffhunk://#diff-206b4c3d6f3351d2be429c8cb655fa22115c8af62a3708b5cadc9239d44c40eaL71-R78): Added a version label to the bottom right of the settings widget to display the current version.